### PR TITLE
use `alpine` for node

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14 AS dependency-base
+FROM node:14-alpine AS dependency-base
 
 # Create app directory
 RUN mkdir /app


### PR DESCRIPTION
A recent deployment failed because space ran out, switched over to `alpine`